### PR TITLE
Fix if statement in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -545,7 +545,7 @@ ENABLE_TESTING()
 # or to "OSMESA" to print all OSMESA variables.
 #
 SET(DEBUG_VARIABLE_PREFIX "")
-IF(NOT (DEBUG_VARIABLE_PREFIX STREQUAL ""))
+IF(NOT ("${DEBUG_VARIABLE_PREFIX}" STREQUAL ""))
     getListOfVarsStartingWith(${DEBUG_VARIABLE_PREFIX} allVars)
     foreach( debugVar IN LISTS allVars ) 
             message(${MSG_TYPE} ${MSG_INDENT} "${debugVar}=${${debugVar}}" )


### PR DESCRIPTION
In the following piece of code in CMakeLists.txt, testing for an empty
string fails (using CMake 3.5.1):

SET(DEBUG_VARIABLE_PREFIX "")
IF(NOT (DEBUG_VARIABLE_PREFIX STREQUAL ""))
    getListOfVarsStartingWith(${DEBUG_VARIABLE_PREFIX} allVars)
    foreach( debugVar IN LISTS allVars ).
            message(${MSG_TYPE} ${MSG_INDENT} "${debugVar}=${${debugVar}}" )
    endforeach()
ENDIF()

This leads to the following error when running cmake:

CMake Error at CMakeLists.txt:549 (getListOfVarsStartingWith):
  getListOfVarsStartingWith Function invoked with incorrect arguments for
  function named: getListOfVarsStartingWith