### PR TITLE
fix link order in wb_command

### DIFF
--- a/src/CommandLine/CMakeLists.txt
+++ b/src/CommandLine/CMakeLists.txt
@@ -93,9 +93,9 @@ Operations
 Algorithms
 OperationsBase
 Brain
+Files
 Graphics
 ${FTGL_LIBRARIES}
-Files
 Annotations
 Palette
 Gifti

--- a/src/Desktop/CMakeLists.txt
+++ b/src/Desktop/CMakeLists.txt
@@ -125,8 +125,8 @@ OperationsBase
 ${Qwt_LIBRARIES}
 OSMesaDummy
 Brain
-Graphics
 Files
+Graphics
 ${FTGL_LIBRARIES}
 Annotations
 Charting

--- a/src/Desktop/CMakeLists.txt
+++ b/src/Desktop/CMakeLists.txt
@@ -126,8 +126,8 @@ ${Qwt_LIBRARIES}
 OSMesaDummy
 Brain
 Graphics
-${FTGL_LIBRARIES}
 Files
+${FTGL_LIBRARIES}
 Annotations
 Charting
 Palette


### PR DESCRIPTION
Link of `wb_command` on Ubuntu 17.10 fails with:

```
[ 99%] Linking CXX executable wb_command
../Files/libFiles.a(ChartableTwoFileHistogramChart.cxx.o): In function
`caret::ChartableTwoFileHistogramChart::getMapHistogramDrawingPrimitives(int,
bool)':
ChartableTwoFileHistogramChart.cxx:(.text+0x112d): undefined reference
to
`caret::GraphicsPrimitiveV3fC4f::GraphicsPrimitiveV3fC4f(caret::GraphicsPrimitive::PrimitiveType)'
```

ie. `Files` calls stuff in `Graphics`, so `Graphics` must come later in the
`wb_comand` link order.

This patch moves Files up a bit and fixes the link.

`test_driver` link also fails, I'll make another PR for that.

**edit** the driver link failure was me not setting `WORKBENCH_MESA_DIR=/usr`, I'll leave that