### PR TITLE
DOC: Changes flag explanation to "right".

### DIFF
--- a/src/Algorithms/AlgorithmCiftiCreateDenseScalar.cxx
+++ b/src/Algorithms/AlgorithmCiftiCreateDenseScalar.cxx
@@ -63,7 +63,7 @@ OperationParameters* AlgorithmCiftiCreateDenseScalar::getParameters()
     OptionalParameter* leftRoiOpt = leftMetricOpt->createOptionalParameter(2, "-roi-left", "roi of vertices to use from left surface");
     leftRoiOpt->addMetricParameter(1, "roi-metric", "the ROI as a metric file");
     
-    OptionalParameter* rightMetricOpt = ret->createOptionalParameter(4, "-right-metric", "metric for left surface");
+    OptionalParameter* rightMetricOpt = ret->createOptionalParameter(4, "-right-metric", "metric for right surface");
     rightMetricOpt->addMetricParameter(1, "metric", "the metric file");
     OptionalParameter* rightRoiOpt = rightMetricOpt->createOptionalParameter(2, "-roi-right", "roi of vertices to use from right surface");
     rightRoiOpt->addMetricParameter(1, "roi-metric", "the ROI as a metric file");


### PR DESCRIPTION
The "-right-metric" flag documentation said "left" instead of "right".  I assumed this was a typo. This PR changes it so the doc now says that "-right-metric" refers to "metric for right surface".