### PR TITLE
Add comma in appliesToMatrixDimension string when encoding XML

### DIFF
--- a/src/Cifti/CiftiXMLWriter.cxx
+++ b/src/Cifti/CiftiXMLWriter.cxx
@@ -159,6 +159,7 @@ void CiftiXMLWriter::writeMatrixIndicesMap(QXmlStreamWriter &xml, const CiftiMat
             int temp = matrixIndicesMap.m_appliesToMatrixDimension[i];
             if (temp < 2 && m_writingVersion.hasReversedFirstDims()) temp = 1 - temp;//in other words, 0 becomes 1 and 1 becomes 0
             appliesToMatrixDimension.append(QString::number(temp));
+            appliesToMatrixDimension.append(","));
         }
         int temp = matrixIndicesMap.m_appliesToMatrixDimension[lastElement];
         if (temp < 2 && m_writingVersion.hasReversedFirstDims()) temp = 1 - temp;//in other words, 0 becomes 1 and 1 becomes 0


### PR DESCRIPTION
In this commit https://github.com/Washington-University/workbench/commit/214710c1af7e02f67ee72599d20b0d008e8c95ac, in file `src/Cifti/CiftiXMLWriter.cxx`, when  
```
appliesToMatrixDimension.append(str.sprintf("%d,",temp));
```
is changed to 
```
appliesToMatrixDimension.append(QString::number(temp));
```
the comma was not included, which causes `-cifti-correlation` operation to fail with segmentation fault error. 
```
caret::CaretAssertion::assertVectorIndexFailed (
    vectorName=0x206e154 "m_indexMaps", vectorNumberOfElements=1, vectorIndex=1, 
    filename=0x206e110 "/home/admin/neuroimaging/workbench/workbench/src/Cifti/CiftiXML.cxx", 
    lineNumber=117)
```