### PR TITLE
Import cstdint into libCZI.h

### DIFF
--- a/src/CZIlib/CZI/libCZI.h
+++ b/src/CZIlib/CZI/libCZI.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "ImportExport.h"
 
 #include "priv_guiddef.h"


### PR DESCRIPTION
Recent libstdc++ has removed `include <stdint.h>` from many headers (see https://gcc.gnu.org/pipermail/gcc-patches/2024-August/659176.html), so libraries that previous relied on transitive imports can fail to compile. The one place this affects workbench is in CZIlib, where `std::uint64_t` is used without including `cstdint`.

I did try importing this immediately above `#include <functional>`, but for some reason that failed. Rather than track down exactly why, I just moved it to the top.