### PR TITLE
Fix unsafe narrowing

### DIFF
--- a/src/Algorithms/AlgorithmCiftiSeparate.cxx
+++ b/src/Algorithms/AlgorithmCiftiSeparate.cxx
@@ -654,7 +654,7 @@ void AlgorithmCiftiSeparate::getCroppedVolSpace(const CiftiFile* ciftiIn, const 
     int64_t numVoxels = (int64_t)myMap.size();
     if (numVoxels > 0)
     {//make a voxel bounding box to minimize memory usage
-        int extrema[6] = { myMap[0].m_ijk[0],
+        int64_t extrema[6] = { myMap[0].m_ijk[0],
             myMap[0].m_ijk[0],
             myMap[0].m_ijk[1],
             myMap[0].m_ijk[1],
@@ -699,7 +699,7 @@ void AlgorithmCiftiSeparate::getCroppedVolSpaceAll(const CiftiFile* ciftiIn, con
     int64_t numVoxels = (int64_t)myMap.size();
     if (numVoxels > 0)
     {//make a voxel bounding box to minimize memory usage
-        int extrema[6] = { myMap[0].m_ijk[0],
+        int64_t extrema[6] = { myMap[0].m_ijk[0],
             myMap[0].m_ijk[0],
             myMap[0].m_ijk[1],
             myMap[0].m_ijk[1],


### PR DESCRIPTION
Attempting to build on OSX with clang, I only got this error (12 times):

`.../src/Algorithms/AlgorithmCiftiSeparate.cxx:657:28: error: non-constant-expression cannot be narrowed from type 'int64_t' (aka 'long long') to 'int' in initializer list [-Wc++11-narrowing]`

The fix is pretty straightforward and compilation ran to completion.