### PR TITLE
Allow disabling Desktop or CommandLine builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,10 @@ set (WORKBENCH_APPLE_WB_COMMAND_BUNDLE_FLAG TRUE CACHE BOOL
            If TRUE, build wb_command as a MacOS Bundle (wb_command.app).
            If FALSE, build wb_command as a normal UNIX executable."
 )
+set (WORKBENCH_BUILD_CLI TRUE CACHE BOOL
+     "If TRUE, build wb_command.")
+set (WORKBENCH_BUILD_GUI TRUE CACHE BOOL
+     "If TRUE, build wb_view.")
 
 #
 # Use when FindOpenMP does not work such as on Macs
@@ -635,13 +639,17 @@ ADD_SUBDIRECTORY ( Algorithms )
 ADD_SUBDIRECTORY ( Operations )
 ADD_SUBDIRECTORY ( Brain )
 ADD_SUBDIRECTORY ( Graphics )
-IF (NOT Qwt_FOUND)
-    ADD_SUBDIRECTORY ( Qwt )
-ENDIF (NOT Qwt_FOUND)
-ADD_SUBDIRECTORY ( GuiQt )
 ADD_SUBDIRECTORY ( Commands )
-ADD_SUBDIRECTORY ( Desktop )
-ADD_SUBDIRECTORY ( CommandLine )
+IF (WORKBENCH_BUILD_CLI)
+  ADD_SUBDIRECTORY ( CommandLine )
+ENDIF (WORKBENCH_BUILD_CLI)
+IF (WORKBENCH_BUILD_GUI)
+  IF (NOT Qwt_FOUND)
+      ADD_SUBDIRECTORY ( Qwt )
+  ENDIF (NOT Qwt_FOUND)
+  ADD_SUBDIRECTORY ( GuiQt )
+  ADD_SUBDIRECTORY ( Desktop )
+ENDIF (WORKBENCH_BUILD_GUI)
 ADD_SUBDIRECTORY ( Tests )
 if (WORKBENCH_USE_SIMD AND CPUINFO_COMPILES)
     ADD_SUBDIRECTORY ( kloewe/cpuinfo )

--- a/src/Tests/CMakeLists.txt
+++ b/src/Tests/CMakeLists.txt
@@ -111,7 +111,6 @@ Tests
 Operations
 Algorithms
 OperationsBase
-GuiQt
 Brain
 Files
 Annotations
@@ -140,6 +139,12 @@ ${ZLIB_LIBRARIES}
 ${OPENMP_LIBRARY}
 #${LIBS}
 )
+
+IF (WORKBENCH_BUILD_GUI)
+    TARGET_LINK_LIBRARIES(test_driver
+    GuiQt
+    )
+ENDIF (WORKBENCH_BUILD_GUI)
 
 IF(WIN32)
     TARGET_LINK_LIBRARIES(test_driver


### PR DESCRIPTION
The internal dependency graph seems to simplify to:

```mermaid
graph LR;
   Desktop --> GuiQt --> AllElse
   Desktop & GuiQt --> Qwt
   Command & Desktop ---> AllElse
```

This is a small patch to allow for either to be disabled. The motivating use case is building a separate conda package for each tool and a meta-package that depends on each:

```mermaid
graph LR;
  connectome-workbench --> connectome-workbench-gui & connectome-workbench-cli
```