### PR TITLE
src/debian/copyright: fix IBMCPL-1.0 block and https:// URLs

### DIFF
--- a/src/debian/copyright
+++ b/src/debian/copyright
@@ -1,6 +1,6 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Connectome Workbench
-Source: http://www.humanconnectome.org/software/get-connectome-workbench.html
+Source: https://www.humanconnectome.org/software/get-connectome-workbench.html
 
 Files: *
 Copyright: 2014-2026 Washington University School of Medicine
@@ -585,20 +585,20 @@ License: HappyBunny
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 
- License: IBMCPL-1.0
-  This library is free software; you can redistribute it and/or modify it
-  under the terms of the Common Public License, version 1.0, as published
-  by IBM, and/or under the terms of the GNU Lesser General Public License,
-  version 2.1, as published by the Free Software Foundation.
-
-  This file is provided "AS IS", without WARRANTIES OR CONDITIONS OF ANY
-  KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY
-  WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR
-  FITNESS FOR A PARTICULAR PURPOSE.
+License: IBMCPL-1.0
+ This library is free software; you can redistribute it and/or modify it
+ under the terms of the Common Public License, version 1.0, as published
+ by IBM, and/or under the terms of the GNU Lesser General Public License,
+ version 2.1, as published by the Free Software Foundation.
  .
-  You should have received a copy of the CPL and the LGPL along with this
-  file. See the LICENSE file and the cpl1.0.txt/lgpl-2.1.txt files
-  included with the source distribution for more information.
-  If you did not receive a copy of the licenses, contact the Qxt Foundation.
+ This file is provided "AS IS", without WARRANTIES OR CONDITIONS OF ANY
+ KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY
+ WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR
+ FITNESS FOR A PARTICULAR PURPOSE.
  .
-  <http://libqxt.org>  <foundation@libqxt.org>
+ You should have received a copy of the CPL and the LGPL along with this
+ file. See the LICENSE file and the cpl1.0.txt/lgpl-2.1.txt files
+ included with the source distribution for more information.
+ If you did not receive a copy of the licenses, contact the Qxt Foundation.
+ .
+ <http://libqxt.org>  <foundation@libqxt.org>


### PR DESCRIPTION
Two small tune-ups for src/debian/copyright, driven by attempts to keep Debian's own debian/copyright close to this file so it doesn't drift over time:

* Format: and Source: fields switched from http:// to https:// (this matches Debian's copyright-format spec and www.humanconnectome.org redirects anyway).

* License: IBMCPL-1.0 block reformatted so it actually parses as a Debian copyright-format 1.0 stanza:
    - remove the leading space on "License: IBMCPL-1.0" (a stanza header must start in column 0)
    - de-indent each body line from 2 spaces to 1 space (copyright- format uses a single-space indent for continuation lines)
    - replace the blank line between the two paragraphs with the " ." paragraph-separator (a bare blank line terminates the stanza and drops the rest of the block from parsers)

No content changes to any license text; purely a formatting fix so the block is recognised by dpkg-parsechangelog / lintian / cme / Debian's copyright-format tooling.